### PR TITLE
upgrade gtest typed tests to test suits

### DIFF
--- a/learn_stl/test/test_any.cc
+++ b/learn_stl/test/test_any.cc
@@ -17,7 +17,7 @@ class AnyTest : public ::testing::Test {
 };
 
 using Types = testing::Types<double, float, int, unsigned char>;
-TYPED_TEST_CASE(AnyTest, Types);
+TYPED_TEST_SUITE(AnyTest, Types);
 
 TYPED_TEST(AnyTest, construction) {
     using learn::any;

--- a/learn_stl/test/test_memory.cc
+++ b/learn_stl/test/test_memory.cc
@@ -10,7 +10,7 @@ template <typename TypeT>
 class AddressOfTest : public ::testing::Test {};
 
 using Types = testing::Types<double, float, int, unsigned char, learn::array<double, 3>>;
-TYPED_TEST_CASE(AddressOfTest, Types);
+TYPED_TEST_SUITE(AddressOfTest, Types);
 
 TYPED_TEST(AddressOfTest, NoOverload) {
     using learn::addressof;
@@ -23,7 +23,7 @@ TYPED_TEST(AddressOfTest, NoOverload) {
 template <typename TypeT>
 class UniquePtrTest : public ::testing::Test {};
 
-TYPED_TEST_CASE(UniquePtrTest, Types);
+TYPED_TEST_SUITE(UniquePtrTest, Types);
 
 TYPED_TEST(UniquePtrTest, CtorsEmpty) {
     using learn::unique_ptr;
@@ -72,7 +72,7 @@ TYPED_TEST(UniquePtrTest, HasValue) {
 template <typename TypeT>
 class MakeUniqueTest : public ::testing::Test {};
 
-TYPED_TEST_CASE(MakeUniqueTest, Types);
+TYPED_TEST_SUITE(MakeUniqueTest, Types);
 
 TYPED_TEST(MakeUniqueTest, Construct) {
     using learn::make_unique;

--- a/learn_stl/test/test_optional.cc
+++ b/learn_stl/test/test_optional.cc
@@ -13,7 +13,7 @@ class OptionalTest : public ::testing::Test {
 };
 
 using Types = testing::Types<double, float, int, unsigned char, learn::array<double, 3>>;
-TYPED_TEST_CASE(OptionalTest, Types);
+TYPED_TEST_SUITE(OptionalTest, Types);
 
 TYPED_TEST(OptionalTest, createEmpty) {
     using Optional = learn::optional<TypeParam>;


### PR DESCRIPTION
Previously `TYPED_TEST_CASE` was used in some of the unit-tests, since then its been depreciated and replaced by `TYPED_TEST_SUITE`. 